### PR TITLE
add nonce fetcher to account contract

### DIFF
--- a/contracts/Account.cairo
+++ b/contracts/Account.cairo
@@ -160,14 +160,38 @@ end
 # Getters
 ###
 
-@external
-func get_public_key{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+@view
+func get_public_key{
+        storage_ptr: Storage*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (
+        res: felt
+    ):
     let (res) = public_key.read()
     return (res=res)
 end
 
-@external
-func get_L1_address{ storage_ptr: Storage*, pedersen_ptr: HashBuiltin*, range_check_ptr }() -> (res: felt):
+@view
+func get_L1_address{
+        storage_ptr: Storage*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (
+        res: felt
+    ):
     let (res) = L1_address.read()
+    return (res=res)
+end
+
+@view
+func get_nonce{
+        storage_ptr: Storage*,
+        pedersen_ptr: HashBuiltin*,
+        range_check_ptr
+    }() -> (
+        res: felt
+    ):
+    let (res) = current_nonce.read()
     return (res=res)
 end

--- a/testing/Account_contract_test.py
+++ b/testing/Account_contract_test.py
@@ -1,11 +1,13 @@
 import pytest
 import asyncio
 from starkware.starknet.testing.starknet import Starknet
-from utils.Signer import Signer
+from utils.Account import Account
 
-signer = Signer(123456789987654321)
+# Create signers that use a private key to sign transaction objects.
+NUM_SIGNING_ACCOUNTS = 2
+DUMMY_PRIVATE = 123456789987654321
+# All accounts currently have the same L1 fallback address.
 L1_ADDRESS = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
-
 
 @pytest.fixture(scope='module')
 def event_loop():
@@ -14,15 +16,41 @@ def event_loop():
 
 @pytest.fixture(scope='module')
 async def account_factory():
+    # Initialize network
     starknet = await Starknet.empty()
-    account = await starknet.deploy("contracts/Account.cairo")
-    await account.initialize(signer.public_key, L1_ADDRESS).invoke()
-    return starknet, account
+    accounts = []
+    print(f'Deploying {NUM_SIGNING_ACCOUNTS} accounts...')
+    for i in range(NUM_SIGNING_ACCOUNTS):
+        account = Account(DUMMY_PRIVATE + i, L1_ADDRESS)
+        await account.create(starknet)
+        accounts.append(account)
+        print(f'Account {i} is: {account}')
+
+    # admin is usually accounts[0], user_1 = accounts[1].
+    # To build a transaction to call func_xyz(arg_1, arg_2)
+    # on a TargetContract:
+
+    # user_1 = accounts[1]
+    # await user_1.tx_with_nonce(
+    #     to=TargetContract,
+    #     selector_name='func_xyz',
+    #     calldata=[arg_1, arg_2])
+    return starknet, accounts
+
+
+@pytest.mark.asyncio
+async def test_account_unique(account_factory):
+    _, accounts = account_factory
+    admin = accounts[0].signer.public_key
+    user_1 = accounts[1].signer.public_key
+    assert admin != user_1
 
 
 @pytest.mark.asyncio
 async def test_initializer(account_factory):
-    _, account = account_factory
-    assert await account.get_public_key().call() == (signer.public_key,)
-    assert await account.get_L1_address().call() == (L1_ADDRESS,)
+    _, accounts = account_factory
+    admin = accounts[0]
+    (key_in_contract, ) = await admin.contract.get_public_key().call()
+    key_in_object = admin.signer.public_key
+    assert key_in_contract == key_in_object
 

--- a/testing/utils/Account.py
+++ b/testing/utils/Account.py
@@ -1,0 +1,38 @@
+from utils.Signer import Signer
+
+ACCOUNT_PATH = "contracts/Account.cairo"
+
+# A deployed contract-based account with nonce awareness.
+class Account():
+    # Initialize with signer. Deploy separately.
+    def __init__(self, private_key, L1_address):
+        self.signer = Signer(private_key)
+        self.L1_address = L1_address
+        self.address = 0
+        self.contract = None
+
+    def __str__(self):
+        addr = hex(self.address)
+        pubkey = hex(self.signer.public_key)
+        return f'Account with address {addr[:6]}...{addr[-4:]} and \
+signer public key {pubkey[:6]}...{pubkey[-4:]}'
+
+    # Deploy. Creates a contract and initializes.
+    async def create(self, starknet):
+        contract = await starknet.deploy(ACCOUNT_PATH)
+        self.contract = contract
+        self.address = contract.contract_address
+        await contract.initialize(self.signer.public_key,
+            self.L1_address).invoke()
+
+    # Transact. Signs and sends a transaction using latest nonce.
+    async def tx_with_nonce(self, to, selector_name, calldata):
+        (nonce, ) = await self.contract.get_nonce().call()
+        transaction = await self.signer.build_transaction(
+            account=self.contract,
+            to=to,
+            selector_name=selector_name,
+            calldata=calldata,
+            nonce=nonce
+        ).invoke()
+        return transaction


### PR DESCRIPTION
This creates a model where multiple accounts can be created and used to send transactions, with automatic nonce handling. The Account.py util calls the account contract to get the current nonce