### PR TITLE
chore(deps): add starknet-devnet and deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp==3.8.0
 aiosignal==1.2.0
+asgiref==3.5.0
 async-timeout==4.0.0
 asynctest==0.13.0
 attrs==21.2.0
@@ -22,6 +23,8 @@ eth-rlp==0.2.1
 eth-typing==2.2.2
 eth-utils==1.9.5
 fastecdsa==2.2.2
+Flask==2.0.3
+Flask-Cors==3.0.10
 frozendict==1.2
 frozenlist==1.2.0
 hexbytes==0.2.2
@@ -29,9 +32,12 @@ idna==3.3
 importlib-metadata==4.8.1
 iniconfig==1.1.1
 ipfshttpclient==0.8.0a2
+itsdangerous==2.1.0
+Jinja2==3.0.3
 jsonschema==3.2.0
 lark-parser==0.12.0
 lru-dict==1.1.7
+MarkupSafe==2.1.0
 marshmallow==3.14.0
 marshmallow-dataclass==8.5.3
 marshmallow-enum==1.5.1
@@ -59,6 +65,7 @@ PyYAML==5.3.1
 requests==2.26.0
 rlp==2.0.1
 six==1.16.0
+starknet-devnet==0.1.16
 sympy==1.9
 toml==0.10.2
 toolz==0.11.1
@@ -69,5 +76,6 @@ urllib3==1.26.7
 varint==1.0.2
 web3==5.24.0
 websockets==9.1
+Werkzeug==2.0.3
 yarl==1.7.2
 zipp==3.6.0


### PR DESCRIPTION
After opening folder in container through the VSCode extension [Remote-Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), I tried to start a local instance StarkNet devnet using `nile node` command. However, it prompted me this message and had to additionally install `starknet-devnet` and after, I was able to run the command successfully. 

![image](https://user-images.githubusercontent.com/35031356/155107192-812e4a30-5626-4864-a7d3-ff7fdf18fa13.png)

I'm creating this PR to update the dependencies after doing a `pip freeze`, please let me know if it's alright 🙂 
